### PR TITLE
docs: update document

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -9,11 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
-        
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # 全履歴を取得する
+
       - name: Extract commit messages
         run: |
-          COMMITS=$(git log --format=%B $(git merge-base origin/develop HEAD)..HEAD)
+          COMMITS=$(git log --format=%B)
           echo "$COMMITS"
           echo "$COMMITS" > commits.txt
       

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -10,15 +10,22 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        
       - name: Extract commit messages
         run: |
           COMMITS=$(git log --format=%B $(git merge-base origin/develop HEAD)..HEAD)
+          echo "$COMMITS"
           echo "$COMMITS" > commits.txt
+      
+      - name: Debug - Print commits
+        run: cat commits.txt
+      
       - name: Set labels based on commit messages
         id: set-labels
         run: |
           labels=()
           while IFS= read -r commit; do
+            echo "Processing commit: $commit"  # デバッグ用出力
             if [[ $commit =~ ^feat ]]; then
               labels+=("feature")
             elif [[ $commit =~ ^fix ]]; then
@@ -39,6 +46,9 @@ jobs:
           # Remove duplicate labels
           unique_labels=($(echo "${labels[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
           
+          # Debug output for unique labels
+          echo "Unique labels: ${unique_labels[*]}"
+
           # Set the output
           echo "labels=${unique_labels[*]}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -51,19 +51,19 @@ jobs:
             fi
           done < commits.txt
           
-          # Remove duplicate labels
-          unique_labels=($(echo "${labels[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+          # Remove duplicate labels and join them as a comma-separated string
+          unique_labels=($(echo "${labels[@]}" | tr ' ' '\n' | sort -u | tr '\n' ','))
           
           # Debug output for unique labels
           echo "Unique labels: ${unique_labels[*]}"
 
-          # Set the output
+          # Set the output as a comma-separated string
           echo "labels=${unique_labels[*]}" >> $GITHUB_OUTPUT
 
       - name: Add labels to PR
         uses: actions-ecosystem/action-add-labels@v1
         with:
-          labels: ${{ steps.set-labels.outputs.labels }}
+          labels: ${{ steps.set-labels.outputs.labels }}  # カンマ区切りのラベルリストを渡す
 
       - name: Assign PR creator
         uses: actions/github-script@v6

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -69,9 +69,9 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            github.rest.issues.addAssignees({
+            await github.rest.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              assignees: [context.actor]  # PRを作成したユーザーをアサイン
+              assignees: [context.actor]  // PRを作成したユーザーをアサイン
             })

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -59,7 +59,9 @@ jobs:
           echo "$unique_labels"
 
           # Set the output as a newline-separated string
-          echo "labels=$unique_labels" >> $GITHUB_OUTPUT
+          echo "labels<<EOF" >> $GITHUB_OUTPUT
+          echo "$unique_labels" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Add labels to PR
         uses: actions-ecosystem/action-add-labels@v1

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -40,9 +40,9 @@ jobs:
               labels+=("bugfix")
             elif [[ $commit =~ ^docs ]]; then
               labels+=("documentation")
+            elif [[ $commit =~ ^style ]]; then
               labels+=("style")
             elif [[ $commit =~ ^refactor ]]; then
-            elif [[ $commit =~ ^style ]]; then
               labels+=("refactor")
             elif [[ $commit =~ ^test ]]; then
               labels+=("test")

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -2,7 +2,9 @@ name: PR Labeler
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize]  # PRの作成時と更新時にトリガー
+    branches:
+      - develop  # developブランチをターゲットにしたPRのみ対象
 
 jobs:
   labeler:
@@ -62,3 +64,14 @@ jobs:
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: ${{ steps.set-labels.outputs.labels }}
+
+      - name: Assign PR creator
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: [context.actor]  # PRを作成したユーザーをアサイン
+            })

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -2,9 +2,9 @@ name: PR Labeler
 
 on:
   pull_request:
-    types: [opened, synchronize]  # PRの作成時と更新時にトリガー
+    types: [opened, synchronize]
     branches:
-      - develop  # developブランチをターゲットにしたPRのみ対象
+      - develop
 
 jobs:
   labeler:
@@ -13,10 +13,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # 全履歴を取得する
+          fetch-depth: 0
 
       - name: Fetch all branches
-        run: git fetch --all  # すべてのリモートブランチ情報をフェッチする
+        run: git fetch --all
 
       - name: Extract commit messages
         run: |
@@ -33,19 +33,21 @@ jobs:
         run: |
           labels=()
           while IFS= read -r commit; do
-            echo "Processing commit: $commit"  # デバッグ用出力
+            echo "Processing commit: $commit"
             if [[ $commit =~ ^feat ]]; then
               labels+=("feature")
             elif [[ $commit =~ ^fix ]]; then
-              labels+=("bug")
+              labels+=("bugfix")
             elif [[ $commit =~ ^docs ]]; then
               labels+=("documentation")
-            elif [[ $commit =~ ^style ]]; then
               labels+=("style")
             elif [[ $commit =~ ^refactor ]]; then
+            elif [[ $commit =~ ^style ]]; then
               labels+=("refactor")
             elif [[ $commit =~ ^test ]]; then
               labels+=("test")
+            elif [[ $commit =~ ^ci ]]; then
+              labels+=("ci")
             elif [[ $commit =~ ^chore ]]; then
               labels+=("chore")
             fi
@@ -66,7 +68,7 @@ jobs:
       - name: Add labels to PR
         uses: actions-ecosystem/action-add-labels@v1
         with:
-          labels: ${{ steps.set-labels.outputs.labels }}  # 改行区切りのラベルリストを渡す
+          labels: ${{ steps.set-labels.outputs.labels }}
 
       - name: Assign PR creator
         uses: actions/github-script@v6
@@ -76,5 +78,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              assignees: [context.actor]  // PRを作成したユーザーをアサイン
+              assignees: [context.actor]
             })

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -51,19 +51,20 @@ jobs:
             fi
           done < commits.txt
           
-          # Remove duplicate labels and join them as a comma-separated string
-          unique_labels=($(echo "${labels[@]}" | tr ' ' '\n' | sort -u | tr '\n' ','))
+          # Remove duplicate labels and join them as a newline-separated string
+          unique_labels=$(printf "%s\n" "${labels[@]}" | sort -u)
           
           # Debug output for unique labels
-          echo "Unique labels: ${unique_labels[*]}"
+          echo "Unique labels:"
+          echo "$unique_labels"
 
-          # Set the output as a comma-separated string
-          echo "labels=${unique_labels[*]}" >> $GITHUB_OUTPUT
+          # Set the output as a newline-separated string
+          echo "labels=$unique_labels" >> $GITHUB_OUTPUT
 
       - name: Add labels to PR
         uses: actions-ecosystem/action-add-labels@v1
         with:
-          labels: ${{ steps.set-labels.outputs.labels }}  # カンマ区切りのラベルリストを渡す
+          labels: ${{ steps.set-labels.outputs.labels }}  # 改行区切りのラベルリストを渡す
 
       - name: Assign PR creator
         uses: actions/github-script@v6

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,48 @@
+name: PR Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Extract commit messages
+        run: |
+          COMMITS=$(git log --format=%B $(git merge-base origin/develop HEAD)..HEAD)
+          echo "$COMMITS" > commits.txt
+      - name: Set labels based on commit messages
+        id: set-labels
+        run: |
+          labels=()
+          while IFS= read -r commit; do
+            if [[ $commit =~ ^feat ]]; then
+              labels+=("feature")
+            elif [[ $commit =~ ^fix ]]; then
+              labels+=("bug")
+            elif [[ $commit =~ ^docs ]]; then
+              labels+=("documentation")
+            elif [[ $commit =~ ^style ]]; then
+              labels+=("style")
+            elif [[ $commit =~ ^refactor ]]; then
+              labels+=("refactor")
+            elif [[ $commit =~ ^test ]]; then
+              labels+=("test")
+            elif [[ $commit =~ ^chore ]]; then
+              labels+=("chore")
+            fi
+          done < commits.txt
+          
+          # Remove duplicate labels
+          unique_labels=($(echo "${labels[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+          
+          # Set the output
+          echo "labels=${unique_labels[*]}" >> $GITHUB_OUTPUT
+
+      - name: Add labels to PR
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: ${{ steps.set-labels.outputs.labels }}

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -9,13 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0  # 全履歴を取得する
 
+      - name: Fetch all branches
+        run: git fetch --all  # すべてのリモートブランチ情報をフェッチする
+
       - name: Extract commit messages
         run: |
-          COMMITS=$(git log --format=%B)
+          # developブランチとの差分のコミットメッセージを取得
+          COMMITS=$(git log --format=%B origin/develop..HEAD)
           echo "$COMMITS"
           echo "$COMMITS" > commits.txt
       

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,16 @@
+# Overview (Uncomment one of the following templates)
+#feat: 
+# └  A new feature
+#fix: 
+# └  A bug fix
+#docs: 
+# └  Documentation only changes
+#style: 
+# └  Changes that do not affect the meaning of the code
+#    (white-space, formatting, missing semi-colons, etc)
+#refactor: 
+# └  A code change that neither fixes a bug nor adds a featur
+#test: 
+# └  Adding missing or correcting existing tests
+#chore: 
+# └  Changes to the build process or auxiliary tools and libraries

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,16 +1,16 @@
 # Overview (Uncomment one of the following templates)
 #feat: 
 # └  A new feature
-#fix: 
+#fix:
 # └  A bug fix
-#docs: 
+#docs:
 # └  Documentation only changes
-#style: 
+#style:
 # └  Changes that do not affect the meaning of the code
 #    (white-space, formatting, missing semi-colons, etc)
-#refactor: 
+#refactor:
 # └  A code change that neither fixes a bug nor adds a featur
-#test: 
+#test:
 # └  Adding missing or correcting existing tests
-#chore: 
+#chore:
 # └  Changes to the build process or auxiliary tools and libraries

--- a/.gitmessage
+++ b/.gitmessage
@@ -12,5 +12,7 @@
 # └  A code change that neither fixes a bug nor adds a featur
 #test:
 # └  Adding missing or correcting existing tests
+#ci:
+# └  Changes to our CI configuration files and scripts
 #chore:
 # └  Changes to the build process or auxiliary tools and libraries

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+	"files.associations": {
+	  ".gitmessage": "plaintext"
+	},
+  }

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,62 @@
+
+# gitmessage
+
+## Conventional Commits
+
+Please loosely follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines for your commit messages.
+
+### Commit Message Format
+
+By using `.gitmessage`, a template for commit messages is provided. This template can be enabled locally for this project by configuring `git config --local`.
+
+```bash
+git config --local commit.template .gitmessage
+```
+
+Once configured, running `git commit` will display the contents of `.gitmessage` in your editor (Vim by default).
+
+```bash
+git commit
+# Overview (Uncomment one of the following templates)
+#feat: 
+# └  A new feature
+#fix:
+# └  A bug fix
+#docs:
+# └  Documentation only changes
+#style:
+# └  Changes that do not affect the meaning of the code
+#    (white-space, formatting, missing semi-colons, etc)
+#refactor:
+# └  A code change that neither fixes a bug nor adds a feature
+#test:
+# └  Adding missing or correcting existing tests
+#ci:
+# └  Changes to our CI configuration files and scripts
+#chore:
+# └  Changes to the build process or auxiliary tools and libraries
+
+```
+
+Select the appropriate template and uncomment it, then write your commit message.
+
+```bash
+docs: Update README.md
+# └  Documentation only changes
+```
+
+## Correspondence between Commit Messages and Labels
+
+When creating a PR to the `develop` branch, labels are automatically assigned based on the commit messages.
+Below is the correspondence between prefixes and labels:
+
+| Prefix | Label | Description |
+|---|---|---|
+|feat: | `feature` | Adding a new feature |
+|fix: | `bugfix` | Bug fixes |
+|docs: | `documentation` | Documentation only changes |
+|style: | `style` | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
+|refactor: | `refactor` | Code changes that neither fix a bug nor add a feature |
+|test: | `test` | Adding or correcting existing tests |
+|ci: | `ci` | Adding or updating CI configuration and scripts |
+|chore: | `chore` | Minor changes or maintenance tasks |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### コミットメッセージのフォーマット
 
 .gitmessageを利用することでコミットメッセージのテンプレートを提供します。
-これはgit config localに設定することで、本プロジェクト内でのみ有効になります。
+これは`git config --local`に設定することで、本プロジェクト内でのみ有効になります。
 
 ```bash
 git config --local commit.template .gitmessage
@@ -18,7 +18,7 @@ git config --local commit.template .gitmessage
 ```bash
 git commit
 # Overview (Uncomment one of the following templates)
-#feat:
+#feat: 
 # └  A new feature
 #fix:
 # └  A bug fix
@@ -31,15 +31,11 @@ git commit
 # └  A code change that neither fixes a bug nor adds a featur
 #test:
 # └  Adding missing or correcting existing tests
+#ci:
+# └  Changes to our CI configuration files and scripts
 #chore:
 # └  Changes to the build process or auxiliary tools and libraries
 
-# Please enter the commit message for your changes. Lines starting
-# with '#' will be ignored, and an empty message aborts the commit.
-#
-# On branch main
-# Your branch is up to date with 'origin/main'.
-#
 ```
 
 適切なテンプレートを選択し、コメントアウトをはずしてコミットメッセージを記述してください。
@@ -52,9 +48,9 @@ docs: Update README.md
 ## コミットメッセージとラベルの対応
 
 `develop`ブランチへのPRを作成するときにコミットメッセージからラベルを自動で付与するように設定しています。
-以下、コミットメッセージとラベルの対応です。
+以下、プレフィックスとラベルの対応です。
 
-|　コミットメッセージ | label | 説明|
+|　プレフィックス | ラベル | 説明|
 |---|---|---|
 |feat: | `feature` | 新機能の追加|
 |fix: | `bugfix` | バグの修正|

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ docs: Update README.md
 
 |　コミットメッセージ | label | 説明|
 |---|---|---|
-|feat: | https://github.com/orangekame3/gitmessage/labels/feature | 新機能の追加|
-|fix: | https://github.com/orangekame3/gitmessage/labels/bugfix | バグの修正|
-|docs: | https://github.com/orangekame3/gitmessage/labels/documentation | ドキュメントのみの変更|
-|style: | https://github.com/orangekame3/gitmessage/labels/style | コードの意味に影響を与えない変更（空白、フォーマット、セミコロンの欠落など）|
-|refactor: | https://github.com/orangekame3/gitmessage/labels/refactor | バグの修正や機能の追加を行わないコードの変更|
-|test: | https://github.com/orangekame3/gitmessage/labels/test | テストの追加、修正|
-|ci: | https://github.com/orangekame3/gitmessage/labels/ci | CIの追加、修正|
-|chore: | https://github.com/orangekame3/gitmessage/labels/chore | 些末な変更 |
+|feat: | [feature](https://github.com/orangekame3/gitmessage/labels/feature) | 新機能の追加|
+|fix: | [bugfix](https://github.com/orangekame3/gitmessage/labels/bugfix) | バグの修正|
+|docs: | [documentation](https://github.com/orangekame3/gitmessage/labels/documentation) | ドキュメントのみの変更|
+|style: | [style](https://github.com/orangekame3/gitmessage/labels/style) | コードの意味に影響を与えない変更（空白、フォーマット、セミコロンの欠落など）|
+|refactor: | [refactor](https://github.com/orangekame3/gitmessage/labels/refactor) | バグの修正や機能の追加を行わないコードの変更|
+|test: | [test](https://github.com/orangekame3/gitmessage/labels/test) | テストの追加、修正|
+|ci: | [ci](https://github.com/orangekame3/gitmessage/labels/ci) | CIの追加、修正|
+|chore: | [chore](https://github.com/orangekame3/gitmessage/labels/chore) | 些末な変更 |

--- a/README.md
+++ b/README.md
@@ -48,3 +48,19 @@ git commit
 docs: Update README.md
 # └  Documentation only changes
 ```
+
+## コミットメッセージとラベルの対応
+
+`develop`ブランチへのPRを作成するときにコミットメッセージからラベルを自動で付与するように設定しています。
+以下、コミットメッセージとラベルの対応です。
+
+|　コミットメッセージ | label | 説明|
+|---|---|---|
+|feat: | https://github.com/orangekame3/gitmessage/labels/feature | 新機能の追加|
+|fix: | https://github.com/orangekame3/gitmessage/labels/bugfix | バグの修正|
+|docs: | https://github.com/orangekame3/gitmessage/labels/documentation | ドキュメントのみの変更|
+|style: | https://github.com/orangekame3/gitmessage/labels/style | コードの意味に影響を与えない変更（空白、フォーマット、セミコロンの欠落など）|
+|refactor: | https://github.com/orangekame3/gitmessage/labels/refactor | バグの修正や機能の追加を行わないコードの変更|
+|test: | https://github.com/orangekame3/gitmessage/labels/test | テストの追加、修正|
+|ci: | https://github.com/orangekame3/gitmessage/labels/ci | CIの追加、修正|
+|chore: | https://github.com/orangekame3/gitmessage/labels/chore | 些末な変更 |

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ docs: Update README.md
 
 |　コミットメッセージ | label | 説明|
 |---|---|---|
-|feat: | [feature](https://github.com/orangekame3/gitmessage/labels/feature) | 新機能の追加|
-|fix: | [bugfix](https://github.com/orangekame3/gitmessage/labels/bugfix) | バグの修正|
-|docs: | [documentation](https://github.com/orangekame3/gitmessage/labels/documentation) | ドキュメントのみの変更|
-|style: | [style](https://github.com/orangekame3/gitmessage/labels/style) | コードの意味に影響を与えない変更（空白、フォーマット、セミコロンの欠落など）|
-|refactor: | [refactor](https://github.com/orangekame3/gitmessage/labels/refactor) | バグの修正や機能の追加を行わないコードの変更|
-|test: | [test](https://github.com/orangekame3/gitmessage/labels/test) | テストの追加、修正|
-|ci: | [ci](https://github.com/orangekame3/gitmessage/labels/ci) | CIの追加、修正|
-|chore: | [chore](https://github.com/orangekame3/gitmessage/labels/chore) | 些末な変更 |
+|feat: | `feature` | 新機能の追加|
+|fix: | `bugfix` | バグの修正|
+|docs: | `documentation` | ドキュメントのみの変更|
+|style: | `style` | コードの意味に影響を与えない変更（空白、フォーマット、セミコロンの欠落など）|
+|refactor: | `refactor` | バグの修正や機能の追加を行わないコードの変更|
+|test: | `test` | テストの追加、修正|
+|ci: | `ci` | CIの追加、修正|
+|chore: | `chore` | 些末な変更 |

--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
 # gitmessage
+
+## Conventional Commits
+
+コミットメッセージは[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)にゆるくしたがってください。
+
+### コミットメッセージのフォーマット
+
+.gitmessageを利用することでコミットメッセージのテンプレートを提供します。
+これはgit config localに設定することで、本プロジェクト内でのみ有効になります。
+
+```bash
+git config --local commit.template .gitmessage
+```
+
+この設定を行うことで、`git commit`を実行した際に`.gitmessage`の内容がエディタ(デフォルトではVim)に表示されます。
+
+```bash
+git commit
+# Overview (Uncomment one of the following templates)
+#feat:
+# └  A new feature
+#fix:
+# └  A bug fix
+#docs:
+# └  Documentation only changes
+#style:
+# └  Changes that do not affect the meaning of the code
+#    (white-space, formatting, missing semi-colons, etc)
+#refactor:
+# └  A code change that neither fixes a bug nor adds a featur
+#test:
+# └  Adding missing or correcting existing tests
+#chore:
+# └  Changes to the build process or auxiliary tools and libraries
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+#
+# On branch main
+# Your branch is up to date with 'origin/main'.
+#
+```
+
+適切なテンプレートを選択し、コメントアウトをはずしてコミットメッセージを記述してください。
+
+```bash
+docs: Update README.md
+# └  Documentation only changes
+```


### PR DESCRIPTION
# gitmessage

## Conventional Commits

コミットメッセージは[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)にゆるくしたがってください。

### コミットメッセージのフォーマット

.gitmessageを利用することでコミットメッセージのテンプレートを提供します。
これはgit config localに設定することで、本プロジェクト内でのみ有効になります。

```bash
git config --local commit.template .gitmessage
```

この設定を行うことで、`git commit`を実行した際に`.gitmessage`の内容がエディタ(デフォルトではVim)に表示されます。

```bash
git commit
# Overview (Uncomment one of the following templates)
#feat:
# └  A new feature
#fix:
# └  A bug fix
#docs:
# └  Documentation only changes
#style:
# └  Changes that do not affect the meaning of the code
#    (white-space, formatting, missing semi-colons, etc)
#refactor:
# └  A code change that neither fixes a bug nor adds a featur
#test:
# └  Adding missing or correcting existing tests
#chore:
# └  Changes to the build process or auxiliary tools and libraries

# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
#
# On branch main
# Your branch is up to date with 'origin/main'.
#
```

適切なテンプレートを選択し、コメントアウトをはずしてコミットメッセージを記述してください。

```bash
docs: Update README.md
# └  Documentation only changes
```

## コミットメッセージとラベルの対応

`develop`ブランチへのPRを作成するときにコミットメッセージからラベルを自動で付与するように設定しています。
以下、コミットメッセージとラベルの対応です。

|　コミットメッセージ | label | 説明|
|---|---|---|
|feat: | `feature` | 新機能の追加|
|fix: | `bugfix` | バグの修正|
|docs: | `documentation` | ドキュメントのみの変更|
|style: | `style` | コードの意味に影響を与えない変更（空白、フォーマット、セミコロンの欠落など）|
|refactor: | `refactor` | バグの修正や機能の追加を行わないコードの変更|
|test: | `test` | テストの追加、修正|
|ci: | `ci` | CIの追加、修正|
|chore: | `chore` | 些末な変更 |
